### PR TITLE
Add example to chop()

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ func main() {
 - [ ] chars
 - [x] chomp
 - [ ] chomp!
-- [x] chop
+- [-] chop
 - [ ] chop!
 - [x] chr
 - [ ] clear

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ func main() {
 - [ ] chars
 - [x] chomp
 - [ ] chomp!
-- [-] chop
+- [x] chop
 - [ ] chop!
 - [x] chr
 - [ ] clear

--- a/xstrings/chop_test.go
+++ b/xstrings/chop_test.go
@@ -1,9 +1,19 @@
 package xstrings
 
 import (
+	"fmt"
 	"github.com/wallclockbuilder/testify/assert"
 	"testing"
 )
+
+func ExampleChop() {
+	fmt.Println(Chop("Keep it simple"))
+	fmt.Println(Chop("Keep it simple\n"))
+	fmt.Println(Chop("Developer happiness FTW\r\n"))
+	// Output: Keep it simpl
+	// Keep it simple
+	// Developer happiness FTW
+}
 
 func TestChop(t *testing.T) {
 	assert.Equal(t, "string", Chop("string\r\n"))


### PR DESCRIPTION
Added examples to chop. They'll show up on godoc.org
Just go there and search for the package name: xstrings
